### PR TITLE
Optimize marker networking

### DIFF
--- a/RCODynAIMines/RCODAMinformationSorter.sqf
+++ b/RCODynAIMines/RCODAMinformationSorter.sqf
@@ -216,9 +216,9 @@ if (_debugOption) then {
 	{
 		_markerIterator = _markerIterator + 1;
 		_markerName = "EnemyTaskforceTestMarker" + str _mineSide + str _markerIterator;
-		_marker = createMarker [_markerName, (_x select 0)];
+		_marker = createMarkerLocal [_markerName, (_x select 0)];
 		
-		_marker setMarkerColor "ColorRed";
+		_marker setMarkerColorLocal "ColorRed";
 		_marker setMarkerType "o_unknown";
 		
 		_debugMarkers pushBack _marker;
@@ -228,9 +228,9 @@ if (_debugOption) then {
 	{
 		_markerIterator = _markerIterator + 1;
 		_markerName = "FriendlyTaskforceTestMarker" + str _mineSide + str _markerIterator;
-		_marker = createMarker [_markerName, (_x select 0)];
+		_marker = createMarkerLocal [_markerName, (_x select 0)];
 		
-		_marker setMarkerColor "ColorBlue";
+		_marker setMarkerColorLocal "ColorBlue";
 		_marker setMarkerType "b_unknown";
 		
 		_debugMarkers pushBack _marker;

--- a/RCODynAIMines/RCODAMmineTaskCreator.sqf
+++ b/RCODynAIMines/RCODAMmineTaskCreator.sqf
@@ -190,8 +190,8 @@ _friendlyAreaMarkers = [];
 	
 	_marker setMarkerShapeLocal "ELLIPSE";
 	_marker setMarkerSizeLocal [800, 800];
-	_marker setMarkerAlphaLocal 0;
 	_marker setMarkerColorLocal "ColorBlue";
+	_marker setMarkerAlpha 0;
 	
 	if (_debugOption) then {
 		_marker setMarkerAlpha 0.7;
@@ -213,8 +213,8 @@ _enemyAreaMarkers = [];
 	
 	_marker setMarkerShapeLocal "ELLIPSE";
 	_marker setMarkerSizeLocal [800, 800];
-	_marker setMarkerAlphaLocal 0;
 	_marker setMarkerColorLocal "ColorRed";
+	_marker setMarkerAlpha 0;
 	
 	if (_debugOption) then {
 		_marker setMarkerAlpha 0.7;
@@ -320,8 +320,8 @@ _DAMdefenceTestingMarkers = [];
 	
 	_marker setMarkerShapeLocal "ELLIPSE";
 	_marker setMarkerSizeLocal [350, 350];
-	_marker setMarkerAlphaLocal 0;
 	_marker setMarkerColorLocal "ColorYellow";
+	_marker setMarkerAlpha 0;
 	
 	if (_debugOption) then {
 	_marker setMarkerAlpha 0.5;
@@ -394,8 +394,8 @@ _marker = createMarkerLocal [_markerName, _DAMinterceptMinefieldPlacement];
 
 _marker setMarkerShapeLocal "ELLIPSE";
 _marker setMarkerSizeLocal [350, 350];
-_marker setMarkerAlphaLocal 0;
 _marker setMarkerColorLocal "ColorYellow";
+_marker setMarkerAlpha 0;
 
 if (_debugOption) then {
 _marker setMarkerAlpha 0.5;
@@ -440,7 +440,7 @@ _DAMinterdictTestingMarkers = [];
 	
 	_marker setMarkerColorLocal "ColorBlack";  
 	_marker setMarkerTypeLocal "hd_dot";  
-	_marker setMarkerAlphaLocal 0;
+	_marker setMarkerAlpha 0;
 	
 	if (_debugOption) then {
 	_marker setMarkerAlpha 1;

--- a/RCODynAIMines/RCODAMmineTaskCreator.sqf
+++ b/RCODynAIMines/RCODAMmineTaskCreator.sqf
@@ -186,12 +186,12 @@ if (isMultiplayer) then {
 _friendlyAreaMarkers = [];
 {
 	_markerName = "FriendlyTaskforceAreaMarker" + str _mineSide + str (_x select 0);
-	_marker = createMarker [_markerName, (_x select 0)];
+	_marker = createMarkerLocal [_markerName, (_x select 0)];
 	
-	_marker setMarkerShape "ELLIPSE";
-	_marker setMarkerSize [800, 800];
-	_marker setMarkerAlpha 0;
-	_marker setMarkerColor "ColorBlue";
+	_marker setMarkerShapeLocal "ELLIPSE";
+	_marker setMarkerSizeLocal [800, 800];
+	_marker setMarkerAlphaLocal 0;
+	_marker setMarkerColorLocal "ColorBlue";
 	
 	if (_debugOption) then {
 		_marker setMarkerAlpha 0.7;
@@ -209,12 +209,12 @@ _enemyAreaMarkers = [];
 	
 {
 	_markerName = "EnemyTaskforceAreaMarker" + str _mineSide + str ((_x select 0) select 0);
-	_marker = createMarker [_markerName, (_x select 0)];
+	_marker = createMarkerLocal [_markerName, (_x select 0)];
 	
-	_marker setMarkerShape "ELLIPSE";
-	_marker setMarkerSize [800, 800];
-	_marker setMarkerAlpha 0;
-	_marker setMarkerColor "ColorRed";
+	_marker setMarkerShapeLocal "ELLIPSE";
+	_marker setMarkerSizeLocal [800, 800];
+	_marker setMarkerAlphaLocal 0;
+	_marker setMarkerColorLocal "ColorRed";
 	
 	if (_debugOption) then {
 		_marker setMarkerAlpha 0.7;
@@ -251,12 +251,12 @@ _DAMdefenceTestingMarkers = [];
 	
 	_markerIterator = _markerIterator + 1;  
 	_markerName = "DAMdefenceTestMarker" + str _markerIterator;  
-	_marker = createMarker [_markerName, _nextMarker];  
+	_marker = createMarkerLocal [_markerName, _nextMarker];  
 	_DAMdefenceTestingMarkers pushBack _marker;
 	
-	_marker setMarkerColor "ColorBlack";  
-	_marker setMarkerType "hd_dot";  
-	_marker setMarkerAlpha 0;
+	_marker setMarkerColorLocal "ColorBlack";  
+	_marker setMarkerTypeLocal "hd_dot";  
+	_marker setMarkerAlphaLocal 0;
 	
 	if (_debugOption) then {
 	_marker setMarkerAlpha 1;
@@ -316,12 +316,12 @@ _DAMdefenceTestingMarkers = [];
 	// Minefield Exclusion Zone
 	
 	_markerName = "TEMPMinefieldExclusionAreaMarker" + str _mineSide + str (_DAMdefenceMinefieldPlacement select 0);
-	_marker = createMarker [_markerName, _DAMdefenceMinefieldPlacement];
+	_marker = createMarkerLocal [_markerName, _DAMdefenceMinefieldPlacement];
 	
-	_marker setMarkerShape "ELLIPSE";
-	_marker setMarkerSize [350, 350];
-	_marker setMarkerAlpha 0;
-	_marker setMarkerColor "ColorYellow";
+	_marker setMarkerShapeLocal "ELLIPSE";
+	_marker setMarkerSizeLocal [350, 350];
+	_marker setMarkerAlphaLocal 0;
+	_marker setMarkerColorLocal "ColorYellow";
 	
 	if (_debugOption) then {
 	_marker setMarkerAlpha 0.5;
@@ -333,9 +333,9 @@ _DAMdefenceTestingMarkers = [];
 	
 	if (_debugOption) then {
 	_markerName = "DefenceObjectiveMarker" + str _DAMdefenceMinefieldPlacement;  
-	_marker = createMarker [_markerName, _DAMdefenceMinefieldPlacement]; 
-	_marker setMarkerColor "ColorBlack";  
-	_marker setMarkerType "hd_dot"; 
+	_marker = createMarkerLocal [_markerName, _DAMdefenceMinefieldPlacement]; 
+	_marker setMarkerColorLocal "ColorBlack";  
+	_marker setMarkerTypeLocal "hd_dot"; 
 	_marker setMarkerText "Defence Objective";	
 	_testerObjectiveAreaMarkers pushBack _marker;
 	};
@@ -390,12 +390,12 @@ _DAMinterceptObjectiveList pushBack [_DAMinterceptMinefieldPlacement,_DAMinterce
 // Minefield Exclusion Zone
 	
 _markerName = "TEMPMinefieldExclusionAreaMarker" + str _mineSide + str (_DAMinterceptMinefieldPlacement select 0);
-_marker = createMarker [_markerName, _DAMinterceptMinefieldPlacement];
+_marker = createMarkerLocal [_markerName, _DAMinterceptMinefieldPlacement];
 
-_marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [350, 350];
-_marker setMarkerAlpha 0;
-_marker setMarkerColor "ColorYellow";
+_marker setMarkerShapeLocal "ELLIPSE";
+_marker setMarkerSizeLocal [350, 350];
+_marker setMarkerAlphaLocal 0;
+_marker setMarkerColorLocal "ColorYellow";
 
 if (_debugOption) then {
 _marker setMarkerAlpha 0.5;
@@ -407,9 +407,9 @@ missionNamespace setVariable [format ["rimmy_dam_var_minefieldExclusionZone_%1",
 
 if (_debugOption) then {
 _markerName = "InterceptObjectiveMarker" + str _DAMinterceptMinefieldPlacement;  
-_marker = createMarker [_markerName, _DAMinterceptMinefieldPlacement]; 
-_marker setMarkerColor "ColorBlue";  
-_marker setMarkerType "hd_dot"; 
+_marker = createMarkerLocal [_markerName, _DAMinterceptMinefieldPlacement]; 
+_marker setMarkerColorLocal "ColorBlue";  
+_marker setMarkerTypeLocal "hd_dot"; 
 _marker setMarkerText "Intercept Objective";	
 _testerObjectiveAreaMarkers pushBack _marker;
 };
@@ -435,12 +435,12 @@ _DAMinterdictTestingMarkers = [];
 	
 	_markerIterator = _markerIterator + 1;  
 	_markerName = "DAMinterdictTestMarker" + str _markerIterator;  
-	_marker = createMarker [_markerName, _nextMarker];  
+	_marker = createMarkerLocal [_markerName, _nextMarker];  
 	_DAMinterdictTestingMarkers pushBack _marker;
 	
-	_marker setMarkerColor "ColorBlack";  
-	_marker setMarkerType "hd_dot";  
-	_marker setMarkerAlpha 0;
+	_marker setMarkerColorLocal "ColorBlack";  
+	_marker setMarkerTypeLocal "hd_dot";  
+	_marker setMarkerAlphaLocal 0;
 	
 	if (_debugOption) then {
 	_marker setMarkerAlpha 1;
@@ -499,12 +499,12 @@ _DAMinterdictTestingMarkers = [];
 	// Minefield Exclusion Zone
 	
 	_markerName = "TEMPMinefieldExclusionAreaMarker" + str _mineSide + str (_DAMinterdictMinefieldPlacement select 0);
-	_marker = createMarker [_markerName, _DAMinterdictMinefieldPlacement];
+	_marker = createMarkerLocal [_markerName, _DAMinterdictMinefieldPlacement];
 
-	_marker setMarkerShape "ELLIPSE";
-	_marker setMarkerSize [350, 350];
-	_marker setMarkerAlpha 0;
-	_marker setMarkerColor "ColorYellow";
+	_marker setMarkerShapeLocal "ELLIPSE";
+	_marker setMarkerSizeLocal [350, 350];
+	_marker setMarkerAlphaLocal 0;
+	_marker setMarkerColorLocal "ColorYellow";
 	
 	if (_debugOption) then {
 	_marker setMarkerAlpha 0.5;
@@ -516,9 +516,9 @@ _DAMinterdictTestingMarkers = [];
 	
 	if (_debugOption) then {
 	_markerName = "InterdictObjectiveMarker" + str _DAMinterdictMinefieldPlacement;  
-	_marker = createMarker [_markerName, _DAMinterdictMinefieldPlacement]; 
-	_marker setMarkerColor "ColorGreen";  
-	_marker setMarkerType "hd_dot"; 
+	_marker = createMarkerLocal [_markerName, _DAMinterdictMinefieldPlacement]; 
+	_marker setMarkerColorLocal "ColorGreen";  
+	_marker setMarkerTypeLocal "hd_dot"; 
 	_marker setMarkerText "Interdict Objective";	
 	_testerObjectiveAreaMarkers pushBack _marker;
 	};

--- a/RCODynAIMines/fn_RCODAMcreateExclusionZone.sqf
+++ b/RCODynAIMines/fn_RCODAMcreateExclusionZone.sqf
@@ -9,12 +9,12 @@ private _debug = _module getVariable "RCODAM_debug";
 private _centreOfZone = getPos _module;
 
 _markerName = "PERMMinefieldExclusionAreaMarker" + _side + str (_centreOfZone select 0);
-_marker = createMarker [_markerName, _centreOfZone];
+_marker = createMarkerLocal [_markerName, _centreOfZone];
 
-_marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [_radiusX, _radiusY];
-_marker setMarkerAlpha 0;
-_marker setMarkerColor "ColorYellow";
+_marker setMarkerShapeLocal "ELLIPSE";
+_marker setMarkerSizeLocal [_radiusX, _radiusY];
+_marker setMarkerAlphaLocal 0;
+_marker setMarkerColorLocal "ColorYellow";
 
 if (_debug) then {
 	_marker setMarkerAlpha 0.5;

--- a/RCODynAIMines/fn_RCODAMcreateExclusionZone.sqf
+++ b/RCODynAIMines/fn_RCODAMcreateExclusionZone.sqf
@@ -13,8 +13,8 @@ _marker = createMarkerLocal [_markerName, _centreOfZone];
 
 _marker setMarkerShapeLocal "ELLIPSE";
 _marker setMarkerSizeLocal [_radiusX, _radiusY];
-_marker setMarkerAlphaLocal 0;
 _marker setMarkerColorLocal "ColorYellow";
+_marker setMarkerAlpha 0;
 
 if (_debug) then {
 	_marker setMarkerAlpha 0.5;

--- a/RCODynAIMines/fn_RCODAMdefenceObjective.sqf
+++ b/RCODynAIMines/fn_RCODAMdefenceObjective.sqf
@@ -74,8 +74,8 @@ _marker = createMarkerLocal [_markerName, _minefieldCentre];
 
 _marker setMarkerShapeLocal "ELLIPSE";
 _marker setMarkerSizeLocal [350, 350];
-_marker setMarkerAlphaLocal 0;
 _marker setMarkerColorLocal "ColorYellow";
+_marker setMarkerAlpha 0;
 
 if (missionNamespace getVariable format ["rimmy_dam_var_debugPerSide_%1", _mineSide]) then {
 	_marker setMarkerAlpha 0.5;
@@ -233,8 +233,8 @@ _marker = createMarkerLocal [_markerName, _minefieldCentre];
 
 _marker setMarkerShapeLocal "ELLIPSE";
 _marker setMarkerSizeLocal [350, 350];
-_marker setMarkerAlphaLocal 0;
 _marker setMarkerColorLocal "ColorYellow";
+_marker setMarkerAlpha 0;
 
 if (missionNamespace getVariable format ["rimmy_dam_var_debugPerSide_%1", _mineSide]) then {
 	_marker setMarkerAlpha 0.5;
@@ -285,8 +285,8 @@ _marker = createMarkerLocal [_markerName, _minefieldCentre];
 
 _marker setMarkerShapeLocal "ELLIPSE";
 _marker setMarkerSizeLocal [350, 350];
-_marker setMarkerAlphaLocal 0;
 _marker setMarkerColorLocal "ColorYellow";
+_marker setMarkerAlpha 0;
 
 if (missionNamespace getVariable format ["rimmy_dam_var_debugPerSide_%1", _mineSide]) then {
 	_marker setMarkerAlpha 0.5;

--- a/RCODynAIMines/fn_RCODAMdefenceObjective.sqf
+++ b/RCODynAIMines/fn_RCODAMdefenceObjective.sqf
@@ -70,12 +70,12 @@ while {_numberOfMinesSpotsDecided < _numberOfMinesToLay} do {
 private _exclusionZoneSecondMaintenance = missionNamespace getVariable format ["rimmy_dam_var_minefieldExclusionZone_%1", _mineSide];
 
 private _markerName = "TEMPMinefieldExclusionAreaMarker" + str _mineSide + str ((_objective select 0) select 0);
-_marker = createMarker [_markerName, _minefieldCentre];
+_marker = createMarkerLocal [_markerName, _minefieldCentre];
 
-_marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [350, 350];
-_marker setMarkerAlpha 0;
-_marker setMarkerColor "ColorYellow";
+_marker setMarkerShapeLocal "ELLIPSE";
+_marker setMarkerSizeLocal [350, 350];
+_marker setMarkerAlphaLocal 0;
+_marker setMarkerColorLocal "ColorYellow";
 
 if (missionNamespace getVariable format ["rimmy_dam_var_debugPerSide_%1", _mineSide]) then {
 	_marker setMarkerAlpha 0.5;
@@ -229,12 +229,12 @@ _exclusionZoneMaintenance deleteAt _markerToRemoveCleanUp;
 deleteMarker _markerToRemove;
 
 private _markerName = "PLANTEDMinefieldExclusionAreaMarker" + str _mineSide + str (_minefieldCentre select 0);
-_marker = createMarker [_markerName, _minefieldCentre];
+_marker = createMarkerLocal [_markerName, _minefieldCentre];
 
-_marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [350, 350];
-_marker setMarkerAlpha 0;
-_marker setMarkerColor "ColorYellow";
+_marker setMarkerShapeLocal "ELLIPSE";
+_marker setMarkerSizeLocal [350, 350];
+_marker setMarkerAlphaLocal 0;
+_marker setMarkerColorLocal "ColorYellow";
 
 if (missionNamespace getVariable format ["rimmy_dam_var_debugPerSide_%1", _mineSide]) then {
 	_marker setMarkerAlpha 0.5;
@@ -281,12 +281,12 @@ _exclusionZoneMaintenance deleteAt _markerToRemoveCleanUp;
 deleteMarker _markerToRemove;
 
 _markerName = "PLANTEDMinefieldExclusionAreaMarker" + str _mineSide + str (_minefieldCentre select 0);
-_marker = createMarker [_markerName, _minefieldCentre];
+_marker = createMarkerLocal [_markerName, _minefieldCentre];
 
-_marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [350, 350];
-_marker setMarkerAlpha 0;
-_marker setMarkerColor "ColorYellow";
+_marker setMarkerShapeLocal "ELLIPSE";
+_marker setMarkerSizeLocal [350, 350];
+_marker setMarkerAlphaLocal 0;
+_marker setMarkerColorLocal "ColorYellow";
 
 if (missionNamespace getVariable format ["rimmy_dam_var_debugPerSide_%1", _mineSide]) then {
 	_marker setMarkerAlpha 0.5;

--- a/RCODynAIMines/fn_RCODAMinterceptObjective.sqf
+++ b/RCODynAIMines/fn_RCODAMinterceptObjective.sqf
@@ -74,8 +74,8 @@ _marker = createMarkerLocal [_markerName, _minefieldCentre];
 
 _marker setMarkerShapeLocal "ELLIPSE";
 _marker setMarkerSizeLocal [350, 350];
-_marker setMarkerAlphaLocal 0;
 _marker setMarkerColorLocal "ColorYellow";
+_marker setMarkerAlpha 0;
 
 if (missionNamespace getVariable format ["rimmy_dam_var_debugPerSide_%1", _mineSide]) then {
 	_marker setMarkerAlpha 0.5;
@@ -233,8 +233,8 @@ _marker = createMarkerLocal [_markerName, _minefieldCentre];
 
 _marker setMarkerShapeLocal "ELLIPSE";
 _marker setMarkerSizeLocal [350, 350];
-_marker setMarkerAlphaLocal 0;
 _marker setMarkerColorLocal "ColorYellow";
+_marker setMarkerAlpha 0;
 
 if (missionNamespace getVariable format ["rimmy_dam_var_debugPerSide_%1", _mineSide]) then {
 	_marker setMarkerAlpha 0.5;
@@ -285,8 +285,8 @@ _marker = createMarkerLocal [_markerName, _minefieldCentre];
 
 _marker setMarkerShapeLocal "ELLIPSE";
 _marker setMarkerSizeLocal [350, 350];
-_marker setMarkerAlphaLocal 0;
 _marker setMarkerColorLocal "ColorYellow";
+_marker setMarkerAlpha 0;
 
 if (missionNamespace getVariable format ["rimmy_dam_var_debugPerSide_%1", _mineSide]) then {
 	_marker setMarkerAlpha 0.5;

--- a/RCODynAIMines/fn_RCODAMinterceptObjective.sqf
+++ b/RCODynAIMines/fn_RCODAMinterceptObjective.sqf
@@ -70,12 +70,12 @@ while {_numberOfMinesSpotsDecided < _numberOfMinesToLay} do {
 private _exclusionZoneSecondMaintenance = missionNamespace getVariable format ["rimmy_dam_var_minefieldExclusionZone_%1", _mineSide];
 
 private _markerName = "TEMPMinefieldExclusionAreaMarker" + str _mineSide + str ((_objective select 0) select 0);
-_marker = createMarker [_markerName, _minefieldCentre];
+_marker = createMarkerLocal [_markerName, _minefieldCentre];
 
-_marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [350, 350];
-_marker setMarkerAlpha 0;
-_marker setMarkerColor "ColorYellow";
+_marker setMarkerShapeLocal "ELLIPSE";
+_marker setMarkerSizeLocal [350, 350];
+_marker setMarkerAlphaLocal 0;
+_marker setMarkerColorLocal "ColorYellow";
 
 if (missionNamespace getVariable format ["rimmy_dam_var_debugPerSide_%1", _mineSide]) then {
 	_marker setMarkerAlpha 0.5;
@@ -229,12 +229,12 @@ _exclusionZoneMaintenance deleteAt _markerToRemoveCleanUp;
 deleteMarker _markerToRemove;
 
 private _markerName = "PLANTEDMinefieldExclusionAreaMarker" + str _mineSide + str (_minefieldCentre select 0);
-_marker = createMarker [_markerName, _minefieldCentre];
+_marker = createMarkerLocal [_markerName, _minefieldCentre];
 
-_marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [350, 350];
-_marker setMarkerAlpha 0;
-_marker setMarkerColor "ColorYellow";
+_marker setMarkerShapeLocal "ELLIPSE";
+_marker setMarkerSizeLocal [350, 350];
+_marker setMarkerAlphaLocal 0;
+_marker setMarkerColorLocal "ColorYellow";
 
 if (missionNamespace getVariable format ["rimmy_dam_var_debugPerSide_%1", _mineSide]) then {
 	_marker setMarkerAlpha 0.5;
@@ -281,12 +281,12 @@ _exclusionZoneMaintenance deleteAt _markerToRemoveCleanUp;
 deleteMarker _markerToRemove;
 
 _markerName = "PLANTEDMinefieldExclusionAreaMarker" + str _mineSide + str (_minefieldCentre select 0);
-_marker = createMarker [_markerName, _minefieldCentre];
+_marker = createMarkerLocal [_markerName, _minefieldCentre];
 
-_marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [350, 350];
-_marker setMarkerAlpha 0;
-_marker setMarkerColor "ColorYellow";
+_marker setMarkerShapeLocal "ELLIPSE";
+_marker setMarkerSizeLocal [350, 350];
+_marker setMarkerAlphaLocal 0;
+_marker setMarkerColorLocal "ColorYellow";
 
 if (missionNamespace getVariable format ["rimmy_dam_var_debugPerSide_%1", _mineSide]) then {
 	_marker setMarkerAlpha 0.5;

--- a/RCODynAIMines/fn_RCODAMinterdictObjective.sqf
+++ b/RCODynAIMines/fn_RCODAMinterdictObjective.sqf
@@ -74,8 +74,8 @@ _marker = createMarkerLocal [_markerName, _minefieldCentre];
 
 _marker setMarkerShapeLocal "ELLIPSE";
 _marker setMarkerSizeLocal [350, 350];
-_marker setMarkerAlphaLocal 0;
 _marker setMarkerColorLocal "ColorYellow";
+_marker setMarkerAlpha 0;
 
 if (missionNamespace getVariable format ["rimmy_dam_var_debugPerSide_%1", _mineSide]) then {
 	_marker setMarkerAlpha 0.5;
@@ -233,8 +233,8 @@ _marker = createMarkerLocal [_markerName, _minefieldCentre];
 
 _marker setMarkerShapeLocal "ELLIPSE";
 _marker setMarkerSizeLocal [350, 350];
-_marker setMarkerAlphaLocal 0;
 _marker setMarkerColorLocal "ColorYellow";
+_marker setMarkerAlpha 0;
 
 if (missionNamespace getVariable format ["rimmy_dam_var_debugPerSide_%1", _mineSide]) then {
 	_marker setMarkerAlpha 0.5;
@@ -285,8 +285,8 @@ _marker = createMarkerLocal [_markerName, _minefieldCentre];
 
 _marker setMarkerShapeLocal "ELLIPSE";
 _marker setMarkerSizeLocal [350, 350];
-_marker setMarkerAlphaLocal 0;
 _marker setMarkerColorLocal "ColorYellow";
+_marker setMarkerAlpha 0;
 
 if (missionNamespace getVariable format ["rimmy_dam_var_debugPerSide_%1", _mineSide]) then {
 	_marker setMarkerAlpha 0.5;

--- a/RCODynAIMines/fn_RCODAMinterdictObjective.sqf
+++ b/RCODynAIMines/fn_RCODAMinterdictObjective.sqf
@@ -70,12 +70,12 @@ while {_numberOfMinesSpotsDecided < _numberOfMinesToLay} do {
 private _exclusionZoneSecondMaintenance = missionNamespace getVariable format ["rimmy_dam_var_minefieldExclusionZone_%1", _mineSide];
 
 private _markerName = "TEMPMinefieldExclusionAreaMarker" + str _mineSide + str ((_objective select 0) select 0);
-_marker = createMarker [_markerName, _minefieldCentre];
+_marker = createMarkerLocal [_markerName, _minefieldCentre];
 
-_marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [350, 350];
-_marker setMarkerAlpha 0;
-_marker setMarkerColor "ColorYellow";
+_marker setMarkerShapeLocal "ELLIPSE";
+_marker setMarkerSizeLocal [350, 350];
+_marker setMarkerAlphaLocal 0;
+_marker setMarkerColorLocal "ColorYellow";
 
 if (missionNamespace getVariable format ["rimmy_dam_var_debugPerSide_%1", _mineSide]) then {
 	_marker setMarkerAlpha 0.5;
@@ -229,12 +229,12 @@ _exclusionZoneMaintenance deleteAt _markerToRemoveCleanUp;
 deleteMarker _markerToRemove;
 
 private _markerName = "PLANTEDMinefieldExclusionAreaMarker" + str _mineSide + str (_minefieldCentre select 0);
-_marker = createMarker [_markerName, _minefieldCentre];
+_marker = createMarkerLocal [_markerName, _minefieldCentre];
 
-_marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [350, 350];
-_marker setMarkerAlpha 0;
-_marker setMarkerColor "ColorYellow";
+_marker setMarkerShapeLocal "ELLIPSE";
+_marker setMarkerSizeLocal [350, 350];
+_marker setMarkerAlphaLocal 0;
+_marker setMarkerColorLocal "ColorYellow";
 
 if (missionNamespace getVariable format ["rimmy_dam_var_debugPerSide_%1", _mineSide]) then {
 	_marker setMarkerAlpha 0.5;
@@ -281,12 +281,12 @@ _exclusionZoneMaintenance deleteAt _markerToRemoveCleanUp;
 deleteMarker _markerToRemove;
 
 _markerName = "PLANTEDMinefieldExclusionAreaMarker" + str _mineSide + str (_minefieldCentre select 0);
-_marker = createMarker [_markerName, _minefieldCentre];
+_marker = createMarkerLocal [_markerName, _minefieldCentre];
 
-_marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [350, 350];
-_marker setMarkerAlpha 0;
-_marker setMarkerColor "ColorYellow";
+_marker setMarkerShapeLocal "ELLIPSE";
+_marker setMarkerSizeLocal [350, 350];
+_marker setMarkerAlphaLocal 0;
+_marker setMarkerColorLocal "ColorYellow";
 
 if (missionNamespace getVariable format ["rimmy_dam_var_debugPerSide_%1", _mineSide]) then {
 	_marker setMarkerAlpha 0.5;


### PR DESCRIPTION
Changed: Many marker commands to local equivalents.

[All marker commands always propagate the entire marker through the network](https://community.bistudio.com/wiki/createMarker), so it is possible to save bandwidth by using a global command only for the final operation.

- [ ] Tested locally
- [ ] Tested on dedicated